### PR TITLE
Se agrega clase content en footer.css

### DIFF
--- a/src/front/js/component/footer.js
+++ b/src/front/js/component/footer.js
@@ -4,6 +4,8 @@ import "../../styles/footer.css"
 export const Footer = () => {
   return (
     <div>
+      {/* <footer className="text-center text-lg-start bg-light text-muted bg-dark footer"> */}
+      {/* <footer className="text-center text-lg-start bg-light text-muted bg-dark fixed-bottom"> */}
       <footer className="text-center text-lg-start bg-light text-muted bg-dark footer">
         <div className="row p-2">
           <div className="text-center col-2">

--- a/src/front/styles/footer.css
+++ b/src/front/styles/footer.css
@@ -1,7 +1,32 @@
-#footer {
+/* .footer {
   width: 100%;
   height: 81px;
-  position: absolute;
+  /* position: absolute; 
   bottom: 0;
   left: 0;
+} */
+
+/* footer {
+  background: #f9f8ba;
+  min-height: 5em;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+} */
+
+/* footer {
+  background: black;
+  color: white;
+  align-self: flex-end;
+  width: 100%;
+  height: 50px;
+  text-align: center;
+} */
+
+.footer {
+  height: 75px;
+}
+
+.content{  
+  min-height: calc(100vh - 225px - 75px);
 }


### PR DESCRIPTION
Esta clase permite ubicar el footer al final de la pagina independientemente de su contenido. Es necesario que todos los div padres de cada componente agreguen la clase "content" para que funcione correctamente.

NOTA:  Hace falta actualizar el valor (en calc) cuando se arregle el alto del navbar.